### PR TITLE
Variable scope

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 node_modules
 npm-debug.log
 tmp

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -72,6 +72,21 @@ module.exports = function(grunt) {
         files: {
           'tmp/page_font_nested_object_no_ns_config.js': ['test/fixtures/page_font_config.properties']
         }
+      },
+      i18n_properties: {
+        options: {
+          namespace: 'i18n'
+        },
+        files: [
+          {
+            expand: true,
+            flatten: true,
+            src: ['test/fixtures/i18n/*.properties'],
+            dest: 'tmp/i18n',
+            ext: '.js',
+            extDot: 'last'
+          }
+        ]
       }
     },
 

--- a/tasks/properties.js
+++ b/tasks/properties.js
@@ -67,8 +67,10 @@ module.exports = function(grunt) {
     // Iterate over all specified file groups.
     this.files.forEach(function(f) {
 
+      var output = src;
+
       // Concat specified files.
-      src += f.src.filter(function(filepath) {
+      output += f.src.filter(function(filepath) {
         // Warn on and remove invalid source files (if nonull was set).
         if (!grunt.file.exists(filepath)) {
           grunt.log.warn('.properties file "' + filepath + '" not found.');
@@ -79,11 +81,11 @@ module.exports = function(grunt) {
       }).map(convert).join('\n');
 
       if (useNS !== true && useKeysSplitter !== true) {
-        src = src.substring(0, src.length - 1) + '\n};';
+        output = output.substring(0, output.length - 1) + '\n};';
       }
 
       // Write the destination file.
-      grunt.file.write(f.dest, src);
+      grunt.file.write(f.dest, output);
 
       // Print a success message.
       grunt.log.writeln('File "' + f.dest + '" created.');

--- a/test/expected/i18n/base.js
+++ b/test/expected/i18n/base.js
@@ -1,0 +1,2 @@
+var i18n = i18n || {};
+i18n["key"] = "test";

--- a/test/expected/i18n/base_de.js
+++ b/test/expected/i18n/base_de.js
@@ -1,0 +1,2 @@
+var i18n = i18n || {};
+i18n["keyDe"] = "test de";

--- a/test/expected/i18n/base_en.js
+++ b/test/expected/i18n/base_en.js
@@ -1,0 +1,2 @@
+var i18n = i18n || {};
+i18n["keyEn"] = "test en";

--- a/test/fixtures/i18n/base.properties
+++ b/test/fixtures/i18n/base.properties
@@ -1,0 +1,1 @@
+key=test

--- a/test/fixtures/i18n/base_de.properties
+++ b/test/fixtures/i18n/base_de.properties
@@ -1,0 +1,1 @@
+keyDe=test de

--- a/test/fixtures/i18n/base_en.properties
+++ b/test/fixtures/i18n/base_en.properties
@@ -1,0 +1,1 @@
+keyEn=test en

--- a/test/properties_test.js
+++ b/test/properties_test.js
@@ -80,5 +80,32 @@ exports.properties = {
     test.equal(actual, expected, 'should generate nested object');
 
     test.done();
+  },
+  i18n_properties_base: function(test) {
+    test.expect(1);
+
+    var actual = grunt.file.read('tmp/i18n/base.js');
+    var expected = grunt.file.read('test/expected/i18n/base.js');
+    test.equal(actual, expected, 'should be without keys from other property files');
+
+    test.done();
+  },
+  i18n_properties_base_en: function(test) {
+    test.expect(1);
+
+    var actual = grunt.file.read('tmp/i18n/base_en.js');
+    var expected = grunt.file.read('test/expected/i18n/base_en.js');
+    test.equal(actual, expected, 'should be without keys from other property files');
+
+    test.done();
+  },
+  i18n_properties_base_de: function(test) {
+    test.expect(1);
+
+    var actual = grunt.file.read('tmp/i18n/base_de.js');
+    var expected = grunt.file.read('test/expected/i18n/base_de.js');
+    test.equal(actual, expected, 'should be without keys from other property files');
+
+    test.done();
   }
 };


### PR DESCRIPTION
If you use [grunt-properties](https://github.com/heldr/grunt-properties) with in a folder loop.

``` js
i18n_properties: {
  options: {
    namespace: 'i18n'
  },
  files: [
    {
      expand: true,
      flatten: true,
      src: ['test/fixtures/i18n/*.properties'],
      dest: 'tmp/i18n',
      ext: '.js',
      extDot: 'last'
    }
  ]
}
```

A bug resolves because of an variable scope bug.
Added tests: `i18n_properties_base`, `i18n_properties_base_en`, `i18n_properties_base_de`.
Bug fix: `/tasks/properties.js`
